### PR TITLE
Add conditional printing to Flambda_cmx_format

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -210,27 +210,35 @@ let merge t1_opt t2_opt =
     in
     Some (t1 @ t2, nsections)
 
-let print0 ~sections ppf t =
+let print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t =
   Format.fprintf ppf "@[<hov>Original unit:@ %a@]@;" Compilation_unit.print
     t.original_compilation_unit;
   Compilation_unit.set_current (Some t.original_compilation_unit);
   let typing_env, code = import_typing_env_and_code0 ~sections t in
-  Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
-    Flambda2_types.Typing_env.Serializable.print typing_env;
-  Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
-  Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print
-    t.exported_offsets
+  if print_typing_env
+  then
+    Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
+      Flambda2_types.Typing_env.Serializable.print typing_env;
+  if print_code
+  then Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
+  if print_offsets
+  then
+    Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print
+      t.exported_offsets
 
-let print ppf (t, sections) =
+let print ~print_typing_env ~print_code ~print_offsets ppf (t, sections) =
   let rec print_rest ppf = function
     | [] -> ()
     | t0 :: t ->
-      Format.fprintf ppf "@ (%a)" (print0 ~sections) t0;
+      Format.fprintf ppf "@ (%a)"
+        (print0 ~sections ~print_typing_env ~print_code ~print_offsets)
+        t0;
       print_rest ppf t
   in
   match t with
   | [] -> assert false
-  | [t0] -> print0 ~sections ppf t0
+  | [t0] -> print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t0
   | t0 :: t ->
-    Format.fprintf ppf "Packed units:@ @[<v>(%a)%a@]" (print0 ~sections) t0
-      print_rest t
+    Format.fprintf ppf "Packed units:@ @[<v>(%a)%a@]"
+      (print0 ~sections ~print_typing_env ~print_code ~print_offsets)
+      t0 print_rest t

--- a/middle_end/flambda2/cmx/flambda_cmx_format.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.mli
@@ -42,4 +42,10 @@ val with_exported_offsets : t -> Exported_offsets.t -> t
 val merge : t option -> t option -> t option
 
 (** For ocamlobjinfo *)
-val print : Format.formatter -> t -> unit
+val print :
+  print_typing_env:bool ->
+  print_code:bool ->
+  print_offsets:bool ->
+  Format.formatter ->
+  t ->
+  unit

--- a/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
+++ b/ocaml/testsuite/tests/tool-ocamlobjinfo/question.ml
@@ -9,7 +9,7 @@
  {
    ocamlobjinfo;
 
-   program = "-no-code question.cmx";
+   program = "-no-code -no-approx question.cmx";
    ocamlobjinfo;
 
    check-program-output;

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -268,13 +268,16 @@ let print_cmx_infos (uir, sections, crc) =
     match uir.uir_export_info with
     | None ->
       printf "Flambda 2 unit (with no export information)\n"
-    | Some _ when !no_code || !no_approx ->
+    | Some _ when !no_code && !no_approx ->
       printf "Flambda 2 unit with export information\n"
     | Some cmx ->
       printf "Flambda 2 export information:\n";
       flush stdout;
+      let print_typing_env = not !no_approx in
+      let print_code = not !no_code in
+      let print_offsets = not (!no_code || !no_approx) in
       let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw cmx ~sections in
-      Format.printf "%a\n%!" Flambda2_cmx.Flambda_cmx_format.print cmx
+      Format.printf "%a\n%!" (Flambda2_cmx.Flambda_cmx_format.print ~print_typing_env ~print_code ~print_offsets) cmx
   end;
   print_generic_fns uir.uir_generic_fns;
   printf "Force link: %s\n" (if uir.uir_force_link then "YES" else "no");

--- a/tools/flambda_backend_objinfo.ml
+++ b/tools/flambda_backend_objinfo.ml
@@ -275,7 +275,7 @@ let print_cmx_infos (uir, sections, crc) =
       flush stdout;
       let print_typing_env = not !no_approx in
       let print_code = not !no_code in
-      let print_offsets = not (!no_code || !no_approx) in
+      let print_offsets = print_code && print_typing_env in
       let cmx = Flambda2_cmx.Flambda_cmx_format.from_raw cmx ~sections in
       Format.printf "%a\n%!" (Flambda2_cmx.Flambda_cmx_format.print ~print_typing_env ~print_code ~print_offsets) cmx
   end;


### PR DESCRIPTION
I saw your PR (ocaml-flambda/flambda-backend#2737) and thought it was a shame that we didn't make the `-no-code` and `-no-approx` work properly, so here is a proposal (on top of your branch) to make it more fine-grained.